### PR TITLE
Fix empty review bug

### DIFF
--- a/server/inquirer/inquirer.py
+++ b/server/inquirer/inquirer.py
@@ -133,7 +133,7 @@ class Inquirer:
         Returns:
             str: The generated JSON.
         """
-        ouput = self.strip_output(output)
+        output = self.strip_output(output)
         output = output.replace("\n", "").replace('\"', '"')
         output = json.loads(output)
         return output

--- a/server/scraper/appstore_textpreprocess.py
+++ b/server/scraper/appstore_textpreprocess.py
@@ -63,4 +63,5 @@ def preprocess_appstore_data(df):
     df['bank'] = df['bank'].str.upper()
     df['source'] = "appstore"
     df['rating'] = df['rating'].astype(int)
+    df = df[df['review'].str.len() > 0]
     return df


### PR DESCRIPTION
Reviews may be processed until empty, but is not removed from the pool of reviews for analysis. Latest changes check for empty reviews post-processing.